### PR TITLE
Allow force parameter on add_job

### DIFF
--- a/hpICsp/jobs.py
+++ b/hpICsp/jobs.py
@@ -58,10 +58,10 @@ class jobs(object):
             body = self._con.get(hpICsp.common.uri['job'])
         return body
 		
-    def add_job(self, body, runTime = None, jobName= None, force= False):
+    def add_job(self, body, runTime = None, jobName = None, force = False):
         if (runTime):
             if (jobName):
-                body = self._con.post(hpICsp.common.uri['job'] + '?time=%s&title=%s' % (runTime,jobName), body)
+                body = self._con.post(hpICsp.common.uri['job'] + '?time=%s&title=%s' % (runTime, jobName), body)
             else:
                 body = self._con.post(hpICsp.common.uri['job'] + '?time=%s' % (runTime), body)			
         elif (jobName):

--- a/hpICsp/jobs.py
+++ b/hpICsp/jobs.py
@@ -58,7 +58,7 @@ class jobs(object):
             body = self._con.get(hpICsp.common.uri['job'])
         return body
 		
-    def add_job(self, body, runTime = None, jobName= None):
+    def add_job(self, body, runTime = None, jobName= None, force= False):
         if (runTime):
             if (jobName):
                 body = self._con.post(hpICsp.common.uri['job'] + '?time=%s&title=%s' % (runTime,jobName), body)
@@ -67,7 +67,10 @@ class jobs(object):
         elif (jobName):
             body = self._con.post(hpICsp.common.uri['job'] + '?title=%s' % (jobName), body)
         else:
-            body = self._con.post(hpICsp.common.uri['job'], body)
+            force_args=''
+            if force:
+                force_args = '?force=true'
+            body = self._con.post(hpICsp.common.uri['job'] + force_args , body)
         return body
 
     def stop_job(self, URI):


### PR DESCRIPTION
Adding a parameter from the public API that was needed on an implementation of an Ansible playbook.
